### PR TITLE
Fix parsing and display of Ulm's ParkAPI data

### DIFF
--- a/app/component/map/popups/DynamicParkingLotsPopup.js
+++ b/app/component/map/popups/DynamicParkingLotsPopup.js
@@ -39,7 +39,10 @@ class DynamicParkingLotsPopup extends React.Component {
   getCapacity() {
     const { intl } = this.context;
     let text;
-    if (this.props.feature.properties && this.props.feature.properties.free) {
+    if (
+      this.props.feature.properties &&
+      typeof this.props.feature.properties.free === 'number'
+    ) {
       text = intl.formatMessage(
         {
           id: 'parking-spaces-available',

--- a/app/component/map/popups/DynamicParkingLotsPopup.js
+++ b/app/component/map/popups/DynamicParkingLotsPopup.js
@@ -41,7 +41,8 @@ class DynamicParkingLotsPopup extends React.Component {
     let text;
     if (
       this.props.feature.properties &&
-      typeof this.props.feature.properties.free === 'number'
+      typeof this.props.feature.properties.free === 'number' &&
+      this.props.feature.properties.state !== 'nodata'
     ) {
       text = intl.formatMessage(
         {

--- a/app/component/map/tile-layer/DynamicParkingLots.js
+++ b/app/component/map/tile-layer/DynamicParkingLots.js
@@ -98,7 +98,7 @@ class DynamicParkingLots {
       geom,
       this.parkingLotImageSize,
     ).then(() => {
-      if (properties.free !== undefined) {
+      if (properties.state !== 'nodata') {
         let avail;
         if (properties.free === 0 || !isOpenNow) {
           avail = 'no';


### PR DESCRIPTION
This PR fixes a few problems with parking lots returning`state:'nodata'` and `free:0` data.

In Ulm the result looks like this:

![Screenshot from 2020-08-31 13-41-49](https://user-images.githubusercontent.com/151346/91716864-b3a56380-eb90-11ea-9f5f-60f545bf9de8.png)
![Screenshot from 2020-08-31 13-40-47](https://user-images.githubusercontent.com/151346/91716867-b43dfa00-eb90-11ea-8ee4-c7b3345bd3fe.png)
![Screenshot from 2020-08-31 13-55-18](https://user-images.githubusercontent.com/151346/91717348-a5a41280-eb91-11ea-910d-ec2339d88ee5.png)
